### PR TITLE
Add controllers (people)

### DIFF
--- a/app/controllers/control_people_controller.rb
+++ b/app/controllers/control_people_controller.rb
@@ -1,0 +1,10 @@
+class ControlPeopleController < ApplicationController
+
+  def index
+    @control_people = ControlPerson.all
+  end
+
+  def show
+    @control_person = ControlPerson.find(params[:id])
+  end
+end

--- a/app/models/control_person.rb
+++ b/app/models/control_person.rb
@@ -1,0 +1,6 @@
+class ControlPerson < AirTable
+  self.air_table_name = "Controllers"
+
+  has_many :power_control_people
+  has_many :powers, through: :power_control_people
+end

--- a/app/models/power.rb
+++ b/app/models/power.rb
@@ -3,4 +3,7 @@ class Power < AirTable
 
   has_many :power_agreements
   has_many :agreements, through: :power_agreements
+
+  has_many :power_control_people
+  has_many :control_people, through: :power_control_people
 end

--- a/app/models/power_agreement.rb
+++ b/app/models/power_agreement.rb
@@ -3,7 +3,7 @@ class PowerAgreement < ApplicationRecord
   belongs_to :agreement
 
   def self.populate
-    Power.all.find_each do |power|
+    Power.find_each do |power|
       (power.fields["Agreement"] || []).each do |agreement_id|
         agreement = Agreement.find_by!(record_id: agreement_id)
         find_or_create_by! power:, agreement:

--- a/app/models/power_control_person.rb
+++ b/app/models/power_control_person.rb
@@ -1,0 +1,13 @@
+class PowerControlPerson < ApplicationRecord
+  belongs_to :power
+  belongs_to :control_person
+
+  def self.populate
+    Power.find_each do |power|
+      (power.fields["Person"] || []).each do |person_id|
+        control_person = ControlPerson.find_by!(record_id: person_id)
+        find_or_create_by! power:, control_person:
+      end
+    end
+  end
+end

--- a/app/views/control_people/index.html.erb
+++ b/app/views/control_people/index.html.erb
@@ -1,0 +1,9 @@
+<h1 class="govuk-heading-l">Controllers</h1>
+
+<ul class="govuk-list">
+<% @control_people.each do |control_person| %>
+  <li>
+    <%= link_to control_person.name, control_person, class: "govuk-link" %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/control_people/show.html.erb
+++ b/app/views/control_people/show.html.erb
@@ -1,7 +1,7 @@
-<h1 class="govuk-heading-l"><%= @power.name %></h1>
+<h1 class="govuk-heading-l"><%= @control_person.name %></h1>
 
 <dl class="govuk-summary-list">
-  <% @power.fields.each do |key, value| %>
+  <% @control_person.fields.each do |key, value| %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key"><%= key.humanize %></dt>
       <dd class="govuk-summary-list__value"><%= value %></dd>
@@ -9,12 +9,13 @@
   <% end %>
 </dl>
 
-<h2 class="govuk-heading-m">Agreements</h2>
+<h2 class="govuk-heading-m">Powers</h2>
 
 <ul class="govuk-list">
-<% @power.agreements.each do |agreement| %>
+<% @control_person.powers.each do |power| %>
   <li>
-    <%= link_to agreement.name, agreement, class: "govuk-link" %>
+    <%= link_to power.name, power, class: "govuk-link" %>
   </li>
 <% end %>
 </ul>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
 
   resources :agreements, only: [:show]
   resources :powers, only: %i[index show]
+  resources :control_people, only: %i[index show], path: :controllers
 end

--- a/db/migrate/20230619152223_create_power_control_people.rb
+++ b/db/migrate/20230619152223_create_power_control_people.rb
@@ -1,0 +1,8 @@
+class CreatePowerControlPeople < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :powers, :control_people, table_name: :power_control_people do |t|
+      t.index %i[power_id control_person_id]
+      t.index %i[control_person_id power_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_15_145223) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_19_152223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +43,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_145223) do
     t.bigint "agreement_id", null: false
     t.index ["agreement_id", "power_id"], name: "index_power_agreements_on_agreement_id_and_power_id"
     t.index ["power_id", "agreement_id"], name: "index_power_agreements_on_power_id_and_agreement_id"
+  end
+
+  create_table "power_control_people", id: false, force: :cascade do |t|
+    t.bigint "power_id", null: false
+    t.bigint "control_person_id", null: false
+    t.index ["control_person_id", "power_id"], name: "index_power_control_people_on_control_person_id_and_power_id"
+    t.index ["power_id", "control_person_id"], name: "index_power_control_people_on_power_id_and_control_person_id"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,16 +4,20 @@
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
 Agreement.populate
+ControlPerson.populate
 Power.populate
 PowerAgreement.populate
+PowerControlPerson.populate
 
 results = {
   agreements: Agreement.count,
+  control_people: ControlPerson.count,
   powers: Power.count,
-  power_agreements: PowerAgreement.count
+  power_agreements: PowerAgreement.count,
+  power_control_people: PowerControlPerson.count
 }
 
-report = ["The following have been create:"]
+report = ["The following have been created:"]
 results.each {|n,c| report << "\t#{n} - #{c}"}
 report = report.join("\n")
 

--- a/spec/factories/control_people.rb
+++ b/spec/factories/control_people.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :control_person do
+    name { Faker::Name.name }
+    record_id { SecureRandom.uuid }
+    fields { { name: } }
+  end
+end

--- a/spec/factories/power_control_people.rb
+++ b/spec/factories/power_control_people.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :power_control_person do
+    control_person
+    power
+  end
+end

--- a/spec/models/control_person_spec.rb
+++ b/spec/models/control_person_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ControlPerson, type: :model do
+  it_behaves_like "is_air_table"
+end

--- a/spec/models/power_control_person_spec.rb
+++ b/spec/models/power_control_person_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe PowerControlPerson, type: :model do
+  describe ".populate" do
+    subject(:populate) { described_class.populate }
+
+    let!(:control_person) { create :control_person }
+    let!(:power) do
+      power = build(:power)
+      power.fields["Person"] = [control_person.record_id]
+      power.save!
+      power
+    end
+
+    it "creates a PowerAgreement" do
+      expect { populate }.to change(described_class, :count).by(1)
+    end
+
+    it "associates the control person with the power" do
+      populate
+      expect(control_person.reload.powers).to include(power)
+    end
+
+    it "associates the power with the control person" do
+      populate
+      expect(power.reload.control_people).to include(control_person)
+    end
+  end
+end

--- a/spec/requests/control_people_spec.rb
+++ b/spec/requests/control_people_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe "/control_people", type: :request do
+  let!(:control_person) { create :control_person }
+
+  describe "GET /control_people index" do
+    it "renders a successful response" do
+      get control_people_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it "displays link to control person" do
+      get control_people_path
+      expect(response.body).to include(control_person_path(control_person))
+    end
+  end
+
+  describe "GET /control_people/:id show" do
+    it "renders a successful response" do
+      get control_person_path(control_person)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "displays control person" do
+      get control_person_path(control_person)
+      expect(response.body).to include(control_person.name)
+    end
+
+    context "when power present" do
+      let(:power_control_person) { create :power_control_person }
+      let(:control_person) { power_control_person.control_person }
+      let(:power) { power_control_person.power }
+
+      it "renders a successful response" do
+        get control_person_path(control_person)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "displays control person" do
+        get control_person_path(control_person)
+        expect(response.body).to include(control_person.name)
+      end
+
+      it "displays a link to the power" do
+        get control_person_path(control_person)
+        expect(response.body).to include(power_path(power))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `ControlPeople` ("Controllers" - used slightly different name to avoid confusion with Rails Controllers)

Also adds join table so that powers can be associated with controllers.

This update includes control people views.