### PR TITLE
Replace list of agreement ids with list of agreement links

### DIFF
--- a/app/views/processors/show.html.erb
+++ b/app/views/processors/show.html.erb
@@ -1,10 +1,15 @@
 <h1 class="govuk-heading-l"><%= @processor.name %></h1>
 
-<dl class="govuk-summary-list">
-  <% @processor.fields.each do |key, value| %>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key"><%= key.humanize %></dt>
-      <dd class="govuk-summary-list__value"><%= value %></dd>
-    </div>
+<p class="govuk-body"><%= @processor.fields['Name'] %></p>
+
+<% if @processor.agreements.present? %>
+  <h2 class="govuk-heading-m">Agreements</h2>
+
+  <ul class="govuk-list">
+  <% @processor.agreements.each do |agreement| %>
+    <li>
+      <%= link_to agreement.name, agreement, class: "govuk-link" %>
+    </li>
   <% end %>
-</dl>
+  </ul>
+<% end %>


### PR DESCRIPTION
Displaying all the fields data for a processor on the processors#show page, output the record ids for the agreements. 

This PR replaces the output such the name is show followed by a section where a list of the agreements (by name) is given with links to those agreements.