### PR TITLE
Update all pages to show agreements as ordered by ID as default

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -10,7 +10,9 @@ class AgreementsController < ApplicationController
     agreements = agreements.where_first_letter(first_letter) if first_letter
     agreements = agreements.where("fields ->> 'ISA_status' = :status", status: isa_status) if isa_status
 
-    agreements = agreements.order(sort_by => direction)
+    # Using reorder because Agreement has a default scope that sets the order
+    # Using unscoped would break the `control_person.agreements` association
+    agreements = agreements.reorder(sort_by => direction)
 
     @pagy, @agreements = pagy(agreements)
   end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -1,6 +1,8 @@
 class Agreement < AirTable
   self.air_table_name = "Information Sharing Agreements"
 
+  default_scope { order(Arel.sql("(fields ->> 'ID')::Integer")) }
+
   has_many :power_agreements, dependent: :delete_all
   has_many :powers, through: :power_agreements
 

--- a/app/models/air_table.rb
+++ b/app/models/air_table.rb
@@ -50,11 +50,11 @@ class AirTable < ApplicationRecord
 
           instance = find_or_initialize_by(record_id: record[:id])
 
-          name = record.dig(:fields, :name) || record.dig(:fields, :Name)
+          name = record.dig(:fields, :name) || record.dig(:fields, :Name) || ""
 
           # If name divided in two by a colon only use the last part in the instance name
-          name = name.split(":").last.strip if name&.count(":") == 1
-          instance.name = name
+          name = name.split(":").last if name&.count(":") == 1
+          instance.name = name.strip
 
           instance.fields = record[:fields]
           instance.save!

--- a/spec/shared_examples/is_air_table.rb
+++ b/spec/shared_examples/is_air_table.rb
@@ -107,10 +107,10 @@ shared_examples_for "is_air_table" do
         expect { populate }.to change(described_class, :count).by(1)
       end
 
-      it "only uses the second part to populate the name attribute" do
+      it "Uses the name as it is but strips off leading/trailing spaces" do
         populate
         record = described_class.last
-        expect(record.name).to eq(name)
+        expect(record.name).to eq(name.strip)
       end
     end
 


### PR DESCRIPTION
Give Agreement a default scope to order by ID

Also:
- Update Agreement#index to ignore default order
- Fix bug in populate that resulted in some Agreement names starting with empty spaces thereby giving odd results when ordered by name