### PR TITLE
Ensure stale agreement associations are removed during population

### DIFF
--- a/app/models/agreement_control_person.rb
+++ b/app/models/agreement_control_person.rb
@@ -3,6 +3,7 @@ class AgreementControlPerson < ApplicationRecord
   belongs_to :control_person
 
   def self.populate
+    delete_all # Simplest way to ensure records deleted from Airtable do not persist in local database
     Agreement.find_each do |agreement|
       (agreement.fields["Controllers"] || []).each do |control_person_id|
         control_person = ControlPerson.find_by(record_id: control_person_id)

--- a/app/models/agreement_processor.rb
+++ b/app/models/agreement_processor.rb
@@ -3,6 +3,7 @@ class AgreementProcessor < ApplicationRecord
   belongs_to :processor
 
   def self.populate
+    delete_all # Simplest way to ensure records deleted from Airtable do not persist in local database
     Agreement.find_each do |agreement|
       (agreement.fields["Processors"] || []).each do |processor_id|
         processor = Processor.find_by(record_id: processor_id)

--- a/app/models/power_agreement.rb
+++ b/app/models/power_agreement.rb
@@ -3,6 +3,7 @@ class PowerAgreement < ApplicationRecord
   belongs_to :agreement
 
   def self.populate
+    delete_all # Simplest way to ensure records deleted from Airtable do not persist in local database
     Agreement.find_each do |agreement|
       (agreement.fields["Power Disclosure"] || []).each do |power_id|
         power = Power.find_by!(record_id: power_id)

--- a/spec/models/agreement_control_person_spec.rb
+++ b/spec/models/agreement_control_person_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe AgreementControlPerson, type: :model do
       populate
       expect(control_person.reload.agreements).to include(agreement)
     end
+
+    describe "with an existing instance" do
+      let!(:agreement_control_person) { create :agreement_control_person }
+
+      it "associates the agreement with the control person" do
+        populate
+        expect(agreement.reload.control_people).to include(control_person)
+      end
+
+      it "deleted the existing association" do
+        expect { populate }.not_to change(described_class, :count) # +1 new, -1 old removed = 0
+      end
+
+      it "existing to be removed" do
+        populate
+        expect(described_class.find_by(agreement_control_person.attributes)).to be_nil
+      end
+    end
   end
 
   describe "associated object behaviour" do

--- a/spec/models/agreement_processor_spec.rb
+++ b/spec/models/agreement_processor_spec.rb
@@ -25,5 +25,23 @@ RSpec.describe AgreementProcessor, type: :model do
       populate
       expect(processor.reload.agreements).to include(agreement)
     end
+
+    describe "with an existing instance" do
+      let!(:agreement_processor) { create :agreement_processor }
+
+      it "associates the agreement with the processor" do
+        populate
+        expect(agreement.reload.processors).to include(processor)
+      end
+
+      it "deleted the existing association" do
+        expect { populate }.not_to change(described_class, :count) # +1 new, -1 old removed = 0
+      end
+
+      it "existing to be removed" do
+        populate
+        expect(described_class.find_by(agreement_processor.attributes)).to be_nil
+      end
+    end
   end
 end

--- a/spec/models/power_agreement_spec.rb
+++ b/spec/models/power_agreement_spec.rb
@@ -25,5 +25,23 @@ RSpec.describe PowerAgreement, type: :model do
       populate
       expect(power.reload.agreements).to include(agreement)
     end
+
+    describe "with an existing instance" do
+      let!(:power_agreement) { create :power_agreement }
+
+      it "associates the agreement with the power" do
+        populate
+        expect(agreement.reload.powers).to include(power)
+      end
+
+      it "deleted the existing association" do
+        expect { populate }.not_to change(described_class, :count) # +1 new, -1 old removed = 0
+      end
+
+      it "existing to be removed" do
+        populate
+        expect(described_class.find_by(power_agreement.attributes)).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This is the fix for https://github.com/co-cddo/dea-register-frontend/issues/50

The problem description was:

> Entry 92 seems like it's pulling both debt and fraud out of Airtable. It was a debt entry that was changed to fraud so that could be why both have been pulled out. On Airtable now, it is only a fraud entry but that isn't reflected on the [gov.uk](http://gov.uk/) staging page we're working on.