### PR TITLE
Increase size and spacing of A-Z selectors to improve accessibility

### DIFF
--- a/app/assets/stylesheets/az_nav.scss
+++ b/app/assets/stylesheets/az_nav.scss
@@ -3,12 +3,12 @@
 
   .az-item {
     display: inline-block;
-    width: 1.3rem;
-    height: 1.3rem;
+    width: 1.75rem;
+    height: 1.75rem;
     background-color: govuk-colour("light-grey");
     padding: 0.25rem;
     text-align: center;
-    margin-bottom: 0.25rem;
+    margin: 0.75rem;
     line-height: inherit;
 
     a, a:visited {


### PR DESCRIPTION
This change causes the A-Z buttons to be a little larger, and with more space between them. This causes the buttons to be displayed in two rows rather than one.