### PR TITLE
Add record of updates to the system

### DIFF
--- a/app/controllers/update_logs_controller.rb
+++ b/app/controllers/update_logs_controller.rb
@@ -1,0 +1,5 @@
+class UpdateLogsController < ApplicationController
+  def index
+    @update_logs = UpdateLog.order(updated_on: :desc, created_at: :desc)
+  end
+end

--- a/app/models/update_log.rb
+++ b/app/models/update_log.rb
@@ -1,0 +1,2 @@
+class UpdateLog < ApplicationRecord
+end

--- a/app/services/log_updates.rb
+++ b/app/services/log_updates.rb
@@ -1,0 +1,50 @@
+class LogUpdates
+  def self.after(time)
+    new(time:).update_log
+  end
+
+  attr_reader :time
+
+  def initialize(time:)
+    @time = time
+  end
+
+  def update_log
+    return unless changes?
+
+    @update_log ||= UpdateLog.create!(updated_on: time, comment: report)
+  end
+
+  def report
+    return unless changes?
+    return created_text if updated_ids.empty?
+
+    [
+      created_text,
+      "Additionally, entries with the following ID numbers have been updated:",
+      updated_ids.to_sentence,
+    ].join(" ")
+  end
+
+  def created_text
+    [
+      number_created,
+      "Agreement".pluralize(number_created),
+      "created.",
+    ].join(" ")
+  end
+
+  def changes?
+    number_created.positive? || updated_ids.present?
+  end
+
+  def number_created
+    @number_created ||= Agreement.where(created_at: time..).count
+  end
+
+  def updated_ids
+    @updated_ids ||= Agreement.where(updated_at: time..)
+                              .where.not(created_at: time..)
+                              .pluck(Arel.sql("fields->'ID'"))
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,8 @@
             Agreements: root_path,
             Powers: powers_path,
             Controllers: control_people_path,
-            Processors: processors_path
+            Processors: processors_path,
+            Updates: update_logs_path,
           }.each do |text, href|
             header.with_navigation_item(text:, href:, active: current_page?(href))
           end

--- a/app/views/update_logs/index.html.erb
+++ b/app/views/update_logs/index.html.erb
@@ -1,0 +1,14 @@
+<% page_title = "Update Log" %>
+
+<h1 class="govuk-heading-l">Record of updates</h1>
+
+<%=
+  govuk_summary_list do |summary_list|
+    @update_logs.each do |update_log|
+      summary_list.with_row do |row|
+        row.with_key(text: update_log.updated_on.strftime("%d %B %Y"))
+        row.with_value(text: update_log.comment)
+      end
+    end
+  end
+%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   resources :processors, only: %i[index show]
   resources :control_people, only: %i[index show], path: :controllers
   resources :search, only: [:index]
+  resources :update_logs, only: [:index]
 end

--- a/db/migrate/20240528130310_create_update_logs.rb
+++ b/db/migrate/20240528130310_create_update_logs.rb
@@ -1,0 +1,11 @@
+class CreateUpdateLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :update_logs do |t|
+      t.date :updated_on
+      t.string :comment
+      t.boolean :from_seeds, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_22_133034) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_28_130310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_22_133034) do
     t.bigint "control_person_id", null: false
     t.index ["control_person_id", "power_id"], name: "index_power_control_people_on_control_person_id_and_power_id"
     t.index ["power_id", "control_person_id"], name: "index_power_control_people_on_power_id_and_control_person_id"
+  end
+
+  create_table "update_logs", force: :cascade do |t|
+    t.date "updated_on"
+    t.string "comment"
+    t.boolean "from_seeds", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/db/seeds/update_record.yml
+++ b/db/seeds/update_record.yml
@@ -1,0 +1,95 @@
+- date: 14 May 2024
+  text: A new searchable version of the register has been uploaded replacing the spreadsheet attachment
+
+- date: 5 March 2024
+  text: new entries added
+
+- date: 20 February 2024
+  text: new entries added
+
+- date: 27 November 2023
+  text: register updated
+
+- date: 30 October 2023
+  text: New entries added.
+
+- date: 28 September 2023
+  text: Register updated
+
+- date: 2 August 2023
+  text: "New register entries added. Additionally, entries with the following ID numbers have been updated: 60,64,92,96 and 215."
+
+- date: 31 March 2023
+  text: New entries added
+
+- date: 9 February 2023
+  text: new entries amended
+
+- date: 9 February 2023
+  text: New entries added
+
+- date: 9 January 2023
+  text: Entries added
+
+- date: 8 December 2022
+  text: New entries added
+
+- date: 9 August 2022
+  text: New entries added. End date of debt pilots on lines 97 - 137 updated.
+
+- date: 1 July 2022
+  text: New entries added.
+
+- date: 17 May 2022
+  text: New entry added.
+
+- date: 10 May 2022
+  text: New entries added. The end date for three water poverty ISAs 94,95,96 have also been amended.
+
+- date: 27 April 2022
+  text: New entry added
+
+- date: 8 April 2022
+  text: new entry added.
+
+- date: 30 March 2022
+  text: New entries added
+
+- date: 13 January 2022
+  text: Register entry no.88 removed.
+
+- date: 7 January 2022
+  text: Register updated. New entries added. ID ref 97, new controllers added.
+
+- date: 9 November 2021
+  text: Register updated. New entries added.
+
+- date: 18 October 2021
+  text: Register updated
+
+- date: 17 September 2021
+  text: Register updated
+
+- date: 14 September 2021
+  text: Register updated.
+
+- date: 1 September 2021
+  text: Register updated
+
+- date: 28 July 2021
+  text: Register updated
+
+- date: 14 July 2021
+  text: Register updated
+
+- date: 24 June 2021
+  text: Register updated.
+
+- date: 27 May 2021
+  text: Register update
+
+- date: 12 May 2021
+  text: Register updated
+
+- date: 30 April 2021
+  text: First published.

--- a/spec/factories/agreements.rb
+++ b/spec/factories/agreements.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :agreement do
     name { Faker::Name.name }
     record_id { SecureRandom.uuid }
-    fields { { name: } }
+    sequence :fields do |n|
+      { name:, ID: n }
+    end
   end
 end

--- a/spec/factories/update_logs.rb
+++ b/spec/factories/update_logs.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :update_log do
+    updated_on { 2.days.ago.to_date }
+    comment { Faker::Lorem.sentence }
+  end
+end

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Agreement, type: :model do
     end
 
     context "when id missing" do
-      let(:agreement) { create :agreement }
+      let(:agreement) { create :agreement, fields: {} }
       it "just returns the name" do
         expect(agreement.id_and_name).to eq(agreement.name)
       end

--- a/spec/requests/update_logs_spec.rb
+++ b/spec/requests/update_logs_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "UpdateLogs", type: :request do
+  describe "GET /index" do
+    let!(:update_log) { create :update_log }
+
+    it "displays log" do
+      get update_logs_path
+      expect(response.body).to include(update_log.comment)
+    end
+  end
+end

--- a/spec/services/log_updates_spec.rb
+++ b/spec/services/log_updates_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+
+RSpec.describe LogUpdates, type: :service do
+  subject { described_class.new(time:) }
+  let(:time) { Time.zone.now }
+  let(:agreement) { create :agreement }
+
+  describe ".after" do
+    it "returns nil if no changes" do
+      expect(described_class.after(time)).to be_nil
+    end
+
+    it "returns an update_log if changes occurred" do
+      time
+      agreement
+      expect { described_class.after(time) }.to change(UpdateLog, :count).by(1)
+    end
+  end
+
+  describe "#update_log" do
+    it "returns nil if no changes" do
+      expect(subject.update_log).to be_nil
+    end
+
+    it "creates a new update log is a change is made" do
+      subject
+      agreement
+      expect { subject.update_log }.to change(UpdateLog, :count).by(1)
+    end
+
+    it "records the report and time in the update log" do
+      subject
+      agreement
+      update_log = subject.update_log
+      expect(update_log.comment).to eq(subject.report)
+      expect(update_log.updated_on).to eq(time.to_date)
+    end
+  end
+
+  describe "#report" do
+    it "is absent if no changes" do
+      expect(subject.report).to be_nil
+    end
+
+    it "gives number of created arguments" do
+      subject
+      agreement
+      expect(subject.report).to eq("1 Agreement created.")
+    end
+
+    it 'pluralizes "Agreements" if more than one created' do
+      subject
+      number = (2..10).to_a.sample
+      create_list :agreement, number
+      expect(subject.report).to eq("#{number} Agreements created.")
+    end
+
+    it "gives ids of updated agreements" do
+      agreement
+      subject # initialize after agreement creation
+      agreement.update!(name: "Foo")
+      expect(subject.report).to eq("0 Agreements created. Additionally, entries with the following ID numbers have been updated: #{agreement.fields['ID']}")
+    end
+
+    it 'lists ids with "and" if multiple updated' do
+      agreements = create_list :agreement, 3
+      subject
+      agreements.each_with_index { |a, i| a.update(name: "Foo #{i}") }
+      expect(subject.report).to include(agreements.last.fields["ID"].to_s)
+      expect(subject.report).to match(/updated:\s\d+,\s\d+,\sand\s\d+/)
+    end
+
+    it "gives ids of updated agreements as well as number of created agreements" do
+      agreement
+      subject # initialize after creation of agreement to be updated
+      create :agreement
+      agreement.update!(name: "Foo")
+      expect(subject.report).to eq("1 Agreement created. Additionally, entries with the following ID numbers have been updated: #{agreement.fields['ID']}")
+    end
+  end
+
+  describe "#changes?" do
+    it "is false if nothing has changed" do
+      expect(subject.changes?).to be_falsey
+    end
+
+    context "with changes" do
+      it "is true if an agreement is created" do
+        subject # initialize to set time
+        agreement
+        expect(subject.changes?).to be_truthy
+      end
+
+      it "is true if agreement is updated" do
+        agreement
+        subject # initialize after agreement creation
+        agreement.update!(name: "Foo")
+        expect(subject.changes?).to be_truthy
+      end
+    end
+  end
+
+  describe "#number_created" do
+    it "is zero if none created" do
+      expect(subject.number_created).to be_zero
+    end
+
+    it "is the number created" do
+      subject
+      create_list :agreement, 3
+      expect(subject.number_created).to eq(3)
+    end
+  end
+
+  describe "#updated_ids" do
+    it "is empty if none updated" do
+      expect(subject.updated_ids).to be_empty
+    end
+
+    it "is empty if some created but not updated" do
+      subject
+      agreement
+      expect(subject.updated_ids).to be_empty
+    end
+
+    it "contains ID of updated agreements" do
+      agreement
+      subject # initialize after agreement creation
+      agreement.update!(name: "Foo")
+      expect(subject.updated_ids).to contain_exactly(agreement.fields["ID"])
+    end
+  end
+end


### PR DESCRIPTION
Adds a new model (`UpdateLog`) that is used to store the date of any changes occurring on update (specifically seeding).

A report is generated as to the nature of the change. This is stored with the new update log, and output to console and logs during seeding.