### PR TITLE
Seed with update logs created prior to move to rAPId

### DIFF
--- a/db/seeds/update_record.yml
+++ b/db/seeds/update_record.yml
@@ -1,3 +1,42 @@
+- date: 30 September 2024
+  text: "20 Agreements created."
+
+- date: 26 September 2024
+  text: "2 Agreements created."
+
+- date: 20 September 2024
+  text: "3 Agreements created. Entries with the following ID numbers have been updated: 96."
+
+- date: 19 September 2024
+  text: "10 Agreements created."
+
+- date: 01 September 2024
+  text: "Entries with the following ID numbers have been updated: 251."
+
+- date: 29 August 2024
+  text: "Entries with the following ID numbers have been updated: 376."
+
+- date: 23 August 2024
+  text: "Entries with the following ID numbers have been updated: 376."
+
+- date: 07 August 2024
+  text: "Entries with the following ID numbers have been updated: 376."
+
+- date: 06 August 2024
+  text: "Entries with the following ID numbers have been updated: 376."
+
+- date: 05 August 2024
+  text: "1 Agreement created."
+
+- date: 16 July 2024
+  text: "Entries with the following ID numbers have been updated: 278."
+
+- date: 10 June 2024
+  text: "Entries with the following ID numbers have been updated: 57."
+
+- date: 05 June 2024
+  text: "Entries with the following ID numbers have been updated: 79 and 80."
+
 - date: 14 May 2024
   text: A new searchable version of the register has been uploaded replacing the spreadsheet attachment
 


### PR DESCRIPTION
Heroku Prod has out of step for a while so hasn't kept in step with the change sequence. We need to add the change log details from the current live version to get everything in step. 