### PR TITLE
Order agreements in power show view

### DIFF
--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -3,7 +3,7 @@ class Agreement < DataTable
   self.rapid_table_name = :agreements
   self.rapid_name_field = :agreement_name
 
-  default_scope { order(Arel.sql("(fields ->> 'ID')::Integer")) }
+  default_scope { order(Arel.sql("CAST(record_id AS Integer)")) }
 
   has_many :power_agreements, dependent: :delete_all
   has_many :powers, through: :power_agreements

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ module DeaRegisterFrontend
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.data_source = ENV.fetch("DATA_SOURCE", :airtable).to_sym
+    # Data source options are :airtable and :rapid
+    config.data_source = ENV.fetch("DATA_SOURCE", :rapid).to_sym
   end
 end

--- a/spec/factories/agreements.rb
+++ b/spec/factories/agreements.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :agreement do
     name { Faker::Name.name }
-    record_id { SecureRandom.uuid }
+    record_id { rand(1..100) }
     sequence :fields do |n|
       { name:, id: n }
     end

--- a/spec/factories/air_table_tables.rb
+++ b/spec/factories/air_table_tables.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :air_table_table do
     name { Faker::Company.name }
-    record_id { SecureRandom.uuid }
+    record_id { rand(1..100) }
   end
 end

--- a/spec/factories/control_people.rb
+++ b/spec/factories/control_people.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :control_person do
     name { Faker::Name.name }
-    record_id { SecureRandom.uuid }
+    record_id { rand(1..100) }
     fields { { name: } }
   end
 end

--- a/spec/factories/data_tables.rb
+++ b/spec/factories/data_tables.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :data_table do
     name { Faker::Company.industry }
-    record_id { SecureRandom.uuid }
+    record_id { rand(1..100) }
     type { %w[Agreement Power ControlPerson].sample }
 
     # NOTE: DataTable is an abstract (STI) class

--- a/spec/factories/powers.rb
+++ b/spec/factories/powers.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :power do
     name { Faker::Name.name }
-    record_id { SecureRandom.uuid }
+    record_id { rand(1..100) }
     fields { { status: "active", name: } }
 
     trait :retired do

--- a/spec/factories/processors.rb
+++ b/spec/factories/processors.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :processor do
     name { Faker::Name.name }
-    record_id { SecureRandom.uuid }
+    record_id { rand(1..100) }
     fields { { name: } }
   end
 end

--- a/spec/models/agreement_processor_spec.rb
+++ b/spec/models/agreement_processor_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe AgreementProcessor, type: :model do
         agreement
       end
 
+      before do
+        allow(Rails.configuration).to receive(:data_source).and_return(:airtable)
+      end
+
       it "creates a new instance" do
         expect { populate }.to change(described_class, :count).by(1)
       end

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Agreement, type: :model do
 
     context "with rAPId source" do
       let(:controller_name) { Faker::Name.name }
-      let(:id) { SecureRandom.uuid }
+      let(:id) { rand(0..1).to_s }
       let(:data) do
         {
           1 => {

--- a/spec/models/power_agreement_spec.rb
+++ b/spec/models/power_agreement_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe PowerAgreement, type: :model do
         agreement
       end
 
+      before do
+        allow(Rails.configuration).to receive(:data_source).and_return(:airtable)
+      end
+
       it "creates a PowerAgreement" do
         expect { populate }.to change(described_class, :count).by(1)
       end

--- a/spec/models/power_control_person_spec.rb
+++ b/spec/models/power_control_person_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe PowerControlPerson, type: :model do
         power
       end
 
+      before do
+        allow(Rails.configuration).to receive(:data_source).and_return(:airtable)
+      end
+
       it "creates a PowerAgreement" do
         expect { populate }.to change(described_class, :count).by(1)
       end

--- a/spec/shared_examples/is_data_table.rb
+++ b/spec/shared_examples/is_data_table.rb
@@ -3,7 +3,7 @@ shared_examples_for "is_data_table" do
     subject(:populate) { described_class.populate }
 
     let(:name) { Faker::Name.name }
-    let(:id) { SecureRandom.uuid }
+    let(:id) { rand(0..100).to_s }
 
     context "with rAPId source" do
       let(:data) do
@@ -113,7 +113,7 @@ shared_examples_for "is_data_table" do
 
         # A second call is then triggered and that needs to return a different set of data
         # As this is then the last set of data, it does not include an offset
-        let(:offset_id) { SecureRandom.uuid }
+        let(:offset_id) { rand(1..100).to_s }
         let(:offset_data) do
           {
             records: [{


### PR DESCRIPTION
Fix error in agreement ordering: order by record_id rather than via fields ->> ID

Also set rAPId as the default data source