### PR TITLE
Clean records on population to remove invalid dates

### DIFF
--- a/app/models/data_table.rb
+++ b/app/models/data_table.rb
@@ -40,7 +40,7 @@ class DataTable < ApplicationRecord
 
         instance.name = name.strip
 
-        instance.fields = record
+        instance.fields = SourceRecordCleaner.clean(record)
         instance.save!
         instance.id
       end

--- a/app/services/source_record_cleaner.rb
+++ b/app/services/source_record_cleaner.rb
@@ -1,0 +1,28 @@
+class SourceRecordCleaner
+  def self.clean(record)
+    new(record).clean
+  end
+
+  attr_reader :record
+
+  def initialize(record)
+    @record = record
+  end
+
+  def clean
+    remove_invalid_dates(:start_date, :end_date, :review_date)
+    record
+  end
+
+  def remove_invalid_dates(*fields)
+    fields.each do |field|
+      record[field] = nil unless valid_date?(record[field])
+    end
+  end
+
+  def valid_date?(date)
+    Time.zone.parse(date)
+  rescue ArgumentError, TypeError
+    false
+  end
+end

--- a/spec/services/source_record_cleaner_spec.rb
+++ b/spec/services/source_record_cleaner_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe SourceRecordCleaner, type: :service do
+  describe ".clean" do
+    subject(:clean) do
+      # Record is updated in processing, so:
+      #   passing in a copy of record so that we can compare with original after processing
+      described_class.clean(record.dup)
+    end
+    let(:name) { Faker::Name.name }
+    let(:id) { rand(0..100).to_s }
+    let(:valid_date) { Faker::Date.in_date_period.to_s }
+
+    let(:record) do
+      {
+        id:,
+        name:,
+        start_date: valid_date,
+        end_date: valid_date,
+        review_date: valid_date,
+      }
+    end
+
+    it "does nothing to valid records" do
+      expect(clean).to eq(record)
+    end
+
+    context "with invalid dates" do
+      let(:record) do
+        {
+          id:,
+          name: "invalid",
+          start_date: "invalid",
+          end_date: "invalid",
+          review_date: "invalid",
+        }
+      end
+
+      it "modifies the record" do
+        expect(clean).not_to eq(record)
+      end
+
+      it "replaces invalid dates with nil" do
+        expect(clean[:start_date]).to be_nil
+        expect(clean[:end_date]).to be_nil
+        expect(clean[:review_date]).to be_nil
+      end
+
+      it "does not change non-date fields" do
+        expect(clean[:name]).to eq("invalid")
+      end
+    end
+  end
+end

--- a/spec/shared_examples/is_data_table.rb
+++ b/spec/shared_examples/is_data_table.rb
@@ -32,6 +32,43 @@ shared_examples_for "is_data_table" do
         expect(record.record_id).to eq(id)
         expect(record.fields["foo"]).to eq("bar")
       end
+
+      context "when contained dates are invalid" do
+        let(:data) do
+          {
+            id => {
+              id:,
+              described_class.rapid_name_field => name,
+              end_date: "invalid",
+            },
+          }
+        end
+
+        it "replaces invalid with null" do
+          populate
+          record = described_class.last
+          expect(record.fields["end_date"]).to be_nil
+        end
+      end
+
+      context "when contained dates are valid" do
+        let(:valid_date) { Faker::Date.in_date_period.to_s }
+        let(:data) do
+          {
+            id => {
+              id:,
+              described_class.rapid_name_field => name,
+              end_date: valid_date,
+            },
+          }
+        end
+
+        it "does not alter date entry" do
+          populate
+          record = described_class.last
+          expect(record.fields["end_date"]).to eq(valid_date)
+        end
+      end
     end
 
     context "with airtable source" do


### PR DESCRIPTION
rAPId cannot handle NULLs so if there is no date the string "Not Available" is added to a date field. This causes problems in the application code if we try to cast the date fields to dates so we can process them as such - specifically in sorting where a string sort will result in a different order to a date sort.

This change update the population process so that the erroneous date entries are removed when the data is imported from rAPId.