### PR TITLE
Add agreements API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,8 +62,8 @@ gem "pagy", "~> 6.0"
 gem "faraday"
 
 # API
-gem 'rabl'
-gem 'oj' # JSON parser
+gem "oj" # JSON parser
+gem "rabl"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,10 @@ gem "pagy", "~> 6.0"
 # HTTP client
 gem "faraday"
 
+# API
+gem 'rabl'
+gem 'oj' # JSON parser
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -149,6 +150,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
+    oj (3.16.7)
+      bigdecimal (>= 3.0)
+      ostruct (>= 0.2)
+    ostruct (0.6.0)
     pagy (6.5.0)
     parallel (1.23.0)
     parser (3.2.2.1)
@@ -165,6 +170,8 @@ GEM
     public_suffix (5.0.1)
     puma (5.6.8)
       nio4r (~> 2.0)
+    rabl (0.16.1)
+      activesupport (>= 2.3.14)
     racc (1.7.3)
     rack (2.2.8.1)
     rack-test (2.1.0)
@@ -296,11 +303,13 @@ DEPENDENCIES
   govuk-components
   govuk_design_system_formbuilder
   jsbundling-rails
+  oj
   pagy (~> 6.0)
   pg (~> 1.1)
   pg_search
   propshaft
   puma (~> 5.6)
+  rabl
   rails (~> 7.0.8)
   rspec-rails (~> 6.0.0)
   rubocop-govuk

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -19,7 +19,7 @@ class AgreementsController < ApplicationController
   end
 
   def show
-    @agreement = Agreement.find(params[:id])
+    @agreement = Agreement.find_by(record_id: params[:id])
   end
 
 private

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -25,4 +25,8 @@ class Agreement < DataTable
   def id_and_name
     [fields["id"], name].select(&:present?).join(" - ")
   end
+
+  def to_param
+    record_id
+  end
 end

--- a/app/views/agreements/index.rabl
+++ b/app/views/agreements/index.rabl
@@ -1,9 +1,9 @@
 object false
-child(@agreements => :agreements) do |agreement|
+child(@agreements => :agreements) do |_agreement|
   node(:data) do |agreement|
     {
       id: agreement.record_id,
-      name: agreement.name
+      name: agreement.name,
     }
   end
   node(:link) do |agreement|
@@ -13,7 +13,7 @@ end
 node(:links) do
   hash = {
     page_size: @pagy.items,
-    current_page: @pagy.page
+    current_page: @pagy.page,
   }
   hash[:next] = Rails.application.routes.url_helpers.agreements_url(page: @pagy.next, format: :json) if @pagy.next
   hash[:previous] = Rails.application.routes.url_helpers.agreements_url(page: @pagy.prev, format: :json) if @pagy.prev
@@ -27,4 +27,3 @@ end
 # node(:link) do |agreement|
 #   Rails.application.routes.url_helpers.agreement_url(agreement, format: :json)
 # end
-

--- a/app/views/agreements/index.rabl
+++ b/app/views/agreements/index.rabl
@@ -1,0 +1,30 @@
+object false
+child(@agreements => :agreements) do |agreement|
+  node(:data) do |agreement|
+    {
+      id: agreement.record_id,
+      name: agreement.name
+    }
+  end
+  node(:link) do |agreement|
+    Rails.application.routes.url_helpers.agreement_url(agreement, format: :json)
+  end
+end
+node(:links) do
+  hash = {
+    page_size: @pagy.items,
+    current_page: @pagy.page
+  }
+  hash[:next] = Rails.application.routes.url_helpers.agreements_url(page: @pagy.next, format: :json) if @pagy.next
+  hash[:previous] = Rails.application.routes.url_helpers.agreements_url(page: @pagy.prev, format: :json) if @pagy.prev
+  hash
+end
+
+# collection @agreements => :agreements
+# node(:data) do |agreement|
+#   { name: agreement.name }
+# end
+# node(:link) do |agreement|
+#   Rails.application.routes.url_helpers.agreement_url(agreement, format: :json)
+# end
+

--- a/app/views/agreements/show.rabl
+++ b/app/views/agreements/show.rabl
@@ -1,0 +1,22 @@
+object @agreement
+node(:data) do |agreement|
+  agreement.fields.except('agreement_name')
+end
+node(:links) do
+  { index: Rails.application.routes.url_helpers.agreements_url(format: :json) }
+end
+child control_people: :controllers do
+  node(:data) do |control_person|
+    { name: control_person.name }
+  end
+end
+child powers: :powers do
+  node(:data) do |power|
+    { name: power.name }
+  end
+end
+child processors: :processors do
+  node(:data) do |processor|
+    { name: processor.name }
+  end
+end

--- a/app/views/agreements/show.rabl
+++ b/app/views/agreements/show.rabl
@@ -1,6 +1,6 @@
 object @agreement
 node(:data) do |agreement|
-  agreement.fields.except('agreement_name')
+  agreement.fields.except("agreement_name")
 end
 node(:links) do
   { index: Rails.application.routes.url_helpers.agreements_url(format: :json) }

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@
 
 require "active_support/core_ext/integer/time"
 
-Rails.application.default_url_options = { host: 'localhost', port: 3000}
+Rails.application.default_url_options = { host: "localhost", port: 3000 }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,6 +2,8 @@
 
 require "active_support/core_ext/integer/time"
 
+Rails.application.default_url_options = { host: 'localhost', port: 3000}
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -2,6 +2,8 @@
 
 require "active_support/core_ext/integer/time"
 
+Rails.application.default_url_options = { host: 'www.digital-economy-act-register.data.gov.uk', protocol: :https }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/heroku.rb
+++ b/config/environments/heroku.rb
@@ -2,7 +2,7 @@
 
 require "active_support/core_ext/integer/time"
 
-Rails.application.default_url_options = { host: 'www.digital-economy-act-register.data.gov.uk', protocol: :https }
+Rails.application.default_url_options = { host: "www.digital-economy-act-register.data.gov.uk", protocol: :https }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,8 @@
 
 require "active_support/core_ext/integer/time"
 
+Rails.application.default_url_options = { host: 'www.digital-economy-act-register.data.gov.uk', protocol: :https }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,7 +2,7 @@
 
 require "active_support/core_ext/integer/time"
 
-Rails.application.default_url_options = { host: 'www.digital-economy-act-register.data.gov.uk', protocol: :https }
+Rails.application.default_url_options = { host: "www.digital-economy-act-register.data.gov.uk", protocol: :https }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,8 @@ require "active_support/core_ext/integer/time"
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
 
+Rails.application.default_url_options = { host: 'localhost', port: 3000 }
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,7 +7,7 @@ require "active_support/core_ext/integer/time"
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
 
-Rails.application.default_url_options = { host: 'localhost', port: 3000 }
+Rails.application.default_url_options = { host: "localhost", port: 3000 }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   root "agreements#index"
 
   resources :agreements, only: [:show]
+  resources :agreements, only: [:show, :index], constraints: { format: :json }
   resources :powers, only: %i[index show]
   resources :processors, only: %i[index show]
   resources :control_people, only: %i[index show], path: :controllers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   root "agreements#index"
 
   resources :agreements, only: [:show]
-  resources :agreements, only: [:show, :index], constraints: { format: :json }
+  resources :agreements, only: %i[show index], constraints: { format: :json }
   resources :powers, only: %i[index show]
   resources :processors, only: %i[index show]
   resources :control_people, only: %i[index show], path: :controllers

--- a/spec/factories/agreements.rb
+++ b/spec/factories/agreements.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :agreement do
     name { Faker::Name.name }
-    record_id { rand(1..100) }
-    sequence :fields do |n|
-      { name:, id: n }
+    sequence :record_id
+    fields do
+      { name:, id: record_id }
     end
   end
 end

--- a/spec/requests/control_people_spec.rb
+++ b/spec/requests/control_people_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "/control_people", type: :request do
 
     it "displays control person" do
       get control_person_path(control_person)
-      expect(response.body).to include(control_person.name)
+      expect(response.body).to include(escape_html(control_person.name))
     end
 
     context "when power present" do
@@ -54,7 +54,7 @@ RSpec.describe "/control_people", type: :request do
 
       it "displays control person" do
         get control_person_path(control_person)
-        expect(response.body).to include(control_person.name)
+        expect(response.body).to include(escape_html(control_person.name))
       end
 
       it "displays a link to the power" do

--- a/spec/requests/processors_spec.rb
+++ b/spec/requests/processors_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "/processors", type: :request do
 
     it "displays processor name" do
       get processor_path(processor)
-      expect(response.body).to include(processor.name)
+      expect(response.body).to include(escape_html(processor.name))
     end
   end
 end

--- a/spec/requests/update_logs_spec.rb
+++ b/spec/requests/update_logs_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "UpdateLogs", type: :request do
 
     it "displays log" do
       get update_logs_path
-      expect(response.body).to include(update_log.comment)
+      expect(response.body).to include(escape_html(update_log.comment))
     end
   end
 end


### PR DESCRIPTION
Update Agreements so they are available via a JSON API interface.

- Also include a fix so that the ID used in agreement URLs is the ID from the data rather than the database id.

With this change in place:

- an Agreement with the ID 123 will have an API rendering at /agreements/123.json. 
- The list of agreements is available at /agreements.json. The list is paginated and next/previous links provided in the data.