### PR TITLE
Determine agreement status from dates

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Configure Ruby and Rails environment
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
@@ -60,7 +60,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       # Add or replace any other lints here

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -14,12 +14,20 @@ class Agreement < DataTable
   has_many :agreement_processors, dependent: :delete_all
   has_many :processors, through: :agreement_processors
 
-  def self.isa_statuses
-    pluck(Arel.sql("fields -> 'isa_status'")).uniq
-  end
+  class << self
+    def isa_statuses
+      pluck(Arel.sql("fields -> 'isa_status'")).uniq
+    end
 
-  def self.find_by_id!(id)
-    find_by!("(fields ->> 'id')::Integer = ?", id.to_i)
+    def find_by_id!(id)
+      find_by!("(fields ->> 'id')::Integer = ?", id.to_i)
+    end
+
+    def before_populate_save(instance)
+      end_date = instance.fields["end_date"].presence
+      status = end_date && (Time.zone.parse(end_date) < Time.zone.now) ? "Complete" : "Active"
+      instance.fields["isa_status"] = status
+    end
   end
 
   def id_and_name

--- a/app/models/data_table.rb
+++ b/app/models/data_table.rb
@@ -52,10 +52,6 @@ class DataTable < ApplicationRecord
       air_table_data_source? ? data_from_air_table : data_from_rapid
     end
 
-    def search(text)
-      search_via_air_table(text)
-    end
-
   private
 
     def is_draft?(record)

--- a/app/models/data_table.rb
+++ b/app/models/data_table.rb
@@ -41,11 +41,17 @@ class DataTable < ApplicationRecord
         instance.name = name.strip
 
         instance.fields = SourceRecordCleaner.clean(record)
+        before_populate_save(instance)
         instance.save!
         instance.id
       end
       # Remove records that no longer match any on the source system(assume deleted)
       where.not(id: ids_of_created).destroy_all
+    end
+
+    def before_populate_save(instance)
+      # By default do nothing
+      # Override in child classes to add modifications specific to that class
     end
 
     def data_from_source

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -37,6 +37,50 @@ RSpec.describe Agreement, type: :model do
         expect(described_class.last.name).to eq("Bar")
       end
     end
+
+    context "with dates" do
+      let(:data) do
+        {
+          1 => {
+            id: 1,
+            agreement_name: "Foo",
+            start_date: 3.days.ago.strftime("%Y-%m-%d"),
+
+          },
+          2 => {
+            id: 2,
+            agreement_name: "Bar",
+            start_date: 3.days.ago.strftime("%Y-%m-%d"),
+            end_date: 2.days.ago.strftime("%Y-%m-%d"),
+
+          },
+          3 => {
+            id: 3,
+            agreement_name: "Other",
+            start_date: 3.days.ago.strftime("%Y-%m-%d"),
+            end_date: 2.days.from_now.strftime("%Y-%m-%d"),
+          },
+        }
+      end
+
+      it "sets status to active if no end date" do
+        populate
+        agreement = described_class.find_by_id!(1)
+        expect(agreement.fields["isa_status"]).to eq("Active")
+      end
+
+      it "sets status to active if end date in past" do
+        populate
+        agreement = described_class.find_by_id!(2)
+        expect(agreement.fields["isa_status"]).to eq("Complete")
+      end
+
+      it "sets status to active if end date in future" do
+        populate
+        agreement = described_class.find_by_id!(3)
+        expect(agreement.fields["isa_status"]).to eq("Active")
+      end
+    end
   end
 
   describe "#id_and_name" do

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe Agreement, type: :model do
   describe ".populate" do # Note that most populate behavior is tested in the shared example 'is_data_table'
     subject(:populate) { described_class.populate }
 
-    context "with rAPId source" do
-      let(:controller_name) { Faker::Name.name }
+    before do
+      allow(Rails.configuration).to receive(:data_source).and_return(:rapid)
+      expect(RapidApi).to receive(:output_for).with(described_class.rapid_table_name).and_return(data)
+    end
+
+    context "with duplicate ids" do
       let(:id) { rand(0..1).to_s }
       let(:data) do
         {
@@ -24,11 +28,6 @@ RSpec.describe Agreement, type: :model do
         }
       end
 
-      before do
-        allow(Rails.configuration).to receive(:data_source).and_return(:rapid)
-        expect(RapidApi).to receive(:output_for).with(described_class.rapid_table_name).and_return(data)
-      end
-
       it "assumes id is unique and does not create duplicates" do
         expect { populate }.to change(described_class, :count).by(1)
       end
@@ -37,37 +36,6 @@ RSpec.describe Agreement, type: :model do
         populate
         expect(described_class.last.name).to eq("Bar")
       end
-    end
-  end
-
-  # make sure a base exists to avoid callout for base
-  let!(:air_table_base) { create :air_table_base }
-  let(:base_id) { AirTableBase.base_id }
-
-  # There needs to be an air table table object to look up the table id
-  let!(:air_table_table) { create :air_table_table, name: described_class.air_table_name }
-  let(:table_id) { air_table_table.record_id }
-
-  describe ".search" do
-    let!(:agreement) { create :agreement, name: "it is all foo bar" }
-    let!(:other) { create :agreement, name: "something else" }
-    let(:data) do
-      { records: [{ id: agreement.record_id }] }
-    end
-    let(:query) do
-      { "filterByFormula" => "SEARCH(\"foo\",{Name})" }
-    end
-
-    before do
-      expect(AirTableApi).to receive(:data_for).with("#{base_id}/#{table_id}", query:).and_return(data)
-    end
-
-    it "returns records that match the query" do
-      expect(described_class.search("foo")).to include(agreement)
-    end
-
-    it "does not return records that do not match the query" do
-      expect(described_class.search("foo")).not_to include(other)
     end
   end
 

--- a/spec/shared_examples/is_data_table.rb
+++ b/spec/shared_examples/is_data_table.rb
@@ -110,7 +110,7 @@ shared_examples_for "is_data_table" do
         record = described_class.last
         expect(record.name).to eq(name)
         expect(record.record_id).to eq(id)
-        expect(record.fields).to eq(fields.stringify_keys)
+        expect(record.fields["foo"]).to eq("bar")
       end
 
       context "when keys are not downcase" do


### PR DESCRIPTION
Update the agreement isa status so that it changes from Active to Complete once the end date is passed.

The change is made during population - so that filter by status works at the data level (rather than just making the modification in the display of the record). 

Also:
- Remove unused search method
- Remove unnecessary agreement spec code